### PR TITLE
Check SHA-1 of NDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
         ndk-version: android-ndk-r19c
 ```
 
-The only required parameter is `ndk-version`. Any version can be passed; however, the orb is only tested against [CircleCI's Android images](https://hub.docker.com/r/circleci/android) with versions `17c`, `18b`, and `19c`.
+There are two required parameters: `ndk-version` and `ndk-sha-1`. Any version and checksum can be passed; however, the orb is only tested against [CircleCI's Android images](https://hub.docker.com/r/circleci/android) with versions `17c`, `18b`, and `19c`.  The list of official SHA-1 checksums is available at: https://developer.android.com/ndk/downloads.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
         ndk-version: android-ndk-r19c
 ```
 
-There are two required parameters: `ndk-version` and `ndk-sha-1`. Any version and checksum can be passed; however, the orb is only tested against [CircleCI's Android images](https://hub.docker.com/r/circleci/android) with versions `17c`, `18b`, and `19c`.  The list of official SHA-1 checksums is available at: https://developer.android.com/ndk/downloads.
+There are two required parameters: `ndk-version` and `ndk-sha-1`. Any version and checksum can be passed; however, the orb is only tested against [CircleCI's Android images](https://hub.docker.com/r/circleci/android) with versions `17c`, `18b`, and `19c` and their checksums. The list of official SHA-1 checksums is available at: https://developer.android.com/ndk/downloads.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ jobs:
 
     - circleci-images/install-android-ndk
         ndk-version: android-ndk-r19c
+        ndk-sha: fd94d0be6017c6acbd193eb95e09cf4b6f61b834
 ```
 
-There are two required parameters: `ndk-version` and `ndk-sha-1`. Any version and checksum can be passed; however, the orb is only tested against [CircleCI's Android images](https://hub.docker.com/r/circleci/android) with versions `17c`, `18b`, and `19c` and their checksums. The list of official SHA-1 checksums is available at: https://developer.android.com/ndk/downloads.
+There are two required parameters: `ndk-version` and `ndk-sha`. Any version and checksum can be passed; however, the orb is only tested against [CircleCI's Android images](https://hub.docker.com/r/circleci/android) with versions `17c`, `18b`, and `19c` and their checksums. The list of official SHA-1 checksums is available at: https://developer.android.com/ndk/downloads.
 
 ## Contributing
 

--- a/src/commands/install-android-ndk.yml
+++ b/src/commands/install-android-ndk.yml
@@ -5,10 +5,16 @@ description: >
 parameters:
   ndk-version:
     type: string
-    default: android-ndk-r17b
+    default: android-ndk-r19c
     description: >
       Version of the NDK to install. Provide a string formatted along
       the lines of the default value.
+  ndk-sha-1:
+    type: string
+    default: fd94d0be6017c6acbd193eb95e09cf4b6f61b834
+    description: >
+      SHA-1 of the zip file specified by ndk-version. Provide a string formatted along
+      the lines of the default value.  See https://developer.android.com/ndk/downloads
 
 steps:
   - run:
@@ -17,6 +23,8 @@ steps:
         curl --silent --show-error --location --fail --retry 3 \
           --output /tmp/<<parameters.ndk-version>>.zip \
           https://dl.google.com/android/repository/<<parameters.ndk-version>>-linux-x86_64.zip && \
+          echo "<<parameters.ndk-sha-1>>  /tmp/<<parameters.ndk-version>>.zip" > /tmp/<<parameters.ndk-version>>.zip.sha1 && \
+          sha1sum -c /tmp/<<parameters.ndk-version>>.zip.sha1 && \
           sudo unzip -q /tmp/<<parameters.ndk-version>>.zip -d /opt/android && \
           rm /tmp/<<parameters.ndk-version>>.zip && \
           sudo chown -R circleci:circleci /opt/android/<<parameters.ndk-version>>

--- a/src/commands/install-android-ndk.yml
+++ b/src/commands/install-android-ndk.yml
@@ -9,7 +9,8 @@ parameters:
     description: >
       Version of the NDK to install. Provide a string formatted along
       the lines of the default value.
-  ndk-sha-1:
+      
+  ndk-sha:
     type: string
     default: fd94d0be6017c6acbd193eb95e09cf4b6f61b834
     description: >
@@ -23,7 +24,7 @@ steps:
         curl --silent --show-error --location --fail --retry 3 \
           --output /tmp/<<parameters.ndk-version>>.zip \
           https://dl.google.com/android/repository/<<parameters.ndk-version>>-linux-x86_64.zip && \
-          echo "<<parameters.ndk-sha-1>>  /tmp/<<parameters.ndk-version>>.zip" > /tmp/<<parameters.ndk-version>>.zip.sha1 && \
+          echo "<<parameters.ndk-sha>>  /tmp/<<parameters.ndk-version>>.zip" > /tmp/<<parameters.ndk-version>>.zip.sha1 && \
           sha1sum -c /tmp/<<parameters.ndk-version>>.zip.sha1 && \
           sudo unzip -q /tmp/<<parameters.ndk-version>>.zip -d /opt/android && \
           rm /tmp/<<parameters.ndk-version>>.zip && \

--- a/src/commands/install-android-ndk.yml
+++ b/src/commands/install-android-ndk.yml
@@ -14,7 +14,7 @@ parameters:
     default: fd94d0be6017c6acbd193eb95e09cf4b6f61b834
     description: >
       SHA-1 of the zip file specified by ndk-version. Provide a string formatted along
-      the lines of the default value.  See https://developer.android.com/ndk/downloads
+      the lines of the default value. See https://developer.android.com/ndk/downloads
 
 steps:
   - run:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Additional security from double-checking that what was downloaded is valid and untampered.

### Description

Add new `ndk-sha-1` string parameter; use that to verify the SHA-1 of the downloaded NDK zip file.  Also, change default version to currently latest NDK.